### PR TITLE
Use older ubtunu to get a older php version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     
     steps:
     - name: install graphviz


### PR DESCRIPTION
With recent ubuntu-latest update the build upgraded to php 8.0 which does not work atm with all dependencies

see https://github.com/FriendsOfREDAXO/phpdoc/runs/1579870419?check_suite_focus=true

> ocramius/package-versions only provides support for Composer 2 in 1.8+, which requires PHP 7.4.
If you can not upgrade PHP you can require composer/package-versions-deprecated to resolve this with PHP 7.0+.
